### PR TITLE
Fix relative URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,12 +1,12 @@
 ## Basic Configuration
-baseurl = "https://easystats.github.io/blog/"
+baseURL = "https://easystats.github.io/blog/"
 languageCode = "en"
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 publishDir = "docs"
 relativeURLs = false
+canonifyURLs = true
 enableEmoji = true
 math = false
-
 title = "easystats"
 theme = "hyde-hyde"
 


### PR DESCRIPTION
I spent slightly longer than I expected on this as I was misled into thinking the issue was to do with the built in partials. I think this should resolve the issue #11  . Tested it and seemed to be working. 

canonifyURLs will ensure that no rendered/generated URLs are relative to the base directory. Please ensure you run hugo_build prior to pushing before pushing back.



